### PR TITLE
fix: add missing use-cases to `disallow-references` rule

### DIFF
--- a/.changeset/nasty-mayflies-compete.md
+++ b/.changeset/nasty-mayflies-compete.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-php': patch
+---
+
+Add missing usecases to `disallow-references` rule

--- a/.changeset/nasty-mayflies-compete.md
+++ b/.changeset/nasty-mayflies-compete.md
@@ -2,4 +2,4 @@
 'eslint-plugin-php': patch
 ---
 
-Add missing usecases to `disallow-references` rule
+Add missing use-cases to `disallow-references` rule

--- a/src/rules/__tests__/disallow-references.test.ts
+++ b/src/rules/__tests__/disallow-references.test.ts
@@ -18,6 +18,7 @@ ruleTester.run(
 			'<?php $a = [1, 2, 3]; $my_var = $a;',
 			'<?php function myFunc($var) { return []; }',
 			'<?php $used = function() use($var) {};',
+			'<?php $fn = function () { return $a; };',
 		],
 		invalid: [
 			{
@@ -87,6 +88,42 @@ ruleTester.run(
 							{
 								messageId: 'removeAmp',
 								output: '<?php $used = function() use($var) {};',
+							},
+						],
+					},
+				],
+			},
+			{
+				code: '<?php $fn = function &() { return $a; };',
+				errors: [
+					{
+						messageId: 'disallowReferences',
+						line: 1,
+						column: 22,
+						endLine: 1,
+						endColumn: 40,
+						suggestions: [
+							{
+								messageId: 'removeAmp',
+								output: '<?php $fn = function () { return $a; };',
+							},
+						],
+					},
+				],
+			},
+			{
+				code: '<?php class A { private function &test2($a) {} }',
+				errors: [
+					{
+						messageId: 'disallowReferences',
+						line: 1,
+						column: 34,
+						endLine: 1,
+						endColumn: 40,
+						suggestions: [
+							{
+								messageId: 'removeAmp',
+								output: '<?php class A { private function test2($a) {} }',
 							},
 						],
 					},

--- a/src/rules/__tests__/disallow-references.test.ts
+++ b/src/rules/__tests__/disallow-references.test.ts
@@ -19,7 +19,7 @@ ruleTester.run(
 			'<?php function myFunc($var) { return []; }',
 			'<?php $used = function() use($var) {};',
 			'<?php $fn = function () { return $a; };',
-			'<?php class A { private function test2($a) {} }'
+			'<?php class A { private function test2($a) {} }',
 		],
 		invalid: [
 			{

--- a/src/rules/__tests__/disallow-references.test.ts
+++ b/src/rules/__tests__/disallow-references.test.ts
@@ -19,6 +19,7 @@ ruleTester.run(
 			'<?php function myFunc($var) { return []; }',
 			'<?php $used = function() use($var) {};',
 			'<?php $fn = function () { return $a; };',
+			'<?php class A { private function test2($a) {} }'
 		],
 		invalid: [
 			{

--- a/src/rules/disallow-references.ts
+++ b/src/rules/disallow-references.ts
@@ -20,9 +20,7 @@ export const disallowReferences = createRule<MessageIds, Options>({
 
 	create(context) {
 		return {
-			'assignref > .right, parameter[byref="true"], function[byref="true"] > .name, variable[byref="true"]'(
-				node,
-			) {
+			[selectors.join(', ')](node) {
 				const ampKeyWord = context.sourceCode.findClosestKeyword(
 					node,
 					'&',
@@ -55,3 +53,12 @@ export const disallowReferences = createRule<MessageIds, Options>({
 		};
 	},
 });
+
+const selectors = [
+	'assignref > .right',
+	'closure[byref="true"]',
+	'variable[byref="true"]',
+	'parameter[byref="true"]',
+	'method[byref="true"] > .name',
+	'function[byref="true"] > .name',
+];


### PR DESCRIPTION
Closes #22 